### PR TITLE
Use null as a separator for xargs

### DIFF
--- a/sendtologstash.sh
+++ b/sendtologstash.sh
@@ -4,4 +4,4 @@ datadir="$(cd "$1" || exit; echo "$PWD")"
 
 echo $datadir
 
-find "$datadir" -name "*puppetserver-access.log" -print0 | xargs cat | nc localhost 5002
+find "$datadir" -name "*puppetserver-access.log" -print0 | xargs -0 cat | nc localhost 5002

--- a/view-in-kibana.sh
+++ b/view-in-kibana.sh
@@ -105,7 +105,7 @@ function load_logs_puppetserver() {
   sleep 10
   echo $datadir
   echo ""
-  find "$datadir" -name "*puppetserver.log" -print0 | xargs cat | nc localhost 5000
+  find "$datadir" -name "*puppetserver.log" -print0 | xargs -0 cat | nc localhost 5000
 }
 
 function load_logs_console_service_api_access() {
@@ -115,7 +115,7 @@ function load_logs_console_service_api_access() {
   sleep 10
   echo $datadir
   echo ""
-  find "$datadir" -name "*console-services-api-access.log" -print0 | xargs cat | nc localhost 5001
+  find "$datadir" -name "*console-services-api-access.log" -print0 | xargs -0 cat | nc localhost 5001
 }
 
 function load_logs_puppet_server_access() {
@@ -125,7 +125,7 @@ function load_logs_puppet_server_access() {
   sleep 10
   echo $datadir
   echo ""
-  find "$datadir" -name "*puppetserver-access.log" -print0 | xargs cat | nc localhost 5002
+  find "$datadir" -name "*puppetserver-access.log" -print0 | xargs -0 cat | nc localhost 5002
 }
 
 function finish() {


### PR DESCRIPTION
This commit updates the invocation of `xargs` in scripts that send data
to logstash to add the `-0` flag which indicates a null byte is being
used as the separator between arguments. This separation is produced
by the use of `-print0` with `find` and GNU `xargs` on Linux will exit
with an error if the corresponding `-0` is not used.