### PR TITLE
Parse request length and duration in access logs

### DIFF
--- a/logstash/pipeline/console-services-api-access-log.conf
+++ b/logstash/pipeline/console-services-api-access-log.conf
@@ -6,10 +6,10 @@ input {
 }
 
 
-filter { 
+filter {
   if [type] == "console-services-api-access" {
     grok {
-      match => { "message" => "%{COMBINEDAPACHELOG}" }
+      match => { "message" => "%{COMBINEDAPACHELOG} %{INT:duration:int}" }
     }
     date {
         match => [ "timestamp", "dd/MMM/yyyy:HH:mm:ss Z" ]

--- a/logstash/pipeline/puppetdb-access-log.conf
+++ b/logstash/pipeline/puppetdb-access-log.conf
@@ -9,7 +9,7 @@ filter {
   if [type] == "puppetdbaccess" {
     grok {
       match => { "message" => 
-        "%{COMBINEDAPACHELOG} %{NUMBER:D} (?<Content>-|[0-9]+)"
+        "%{COMBINEDAPACHELOG} %{INT:duration:int} (?:%{INT:request_bytes:int}|-)"
         }
       }
     date {

--- a/logstash/pipeline/puppetserver-access.conf
+++ b/logstash/pipeline/puppetserver-access.conf
@@ -8,8 +8,10 @@ input {
 filter {
   if [type] == "puppetaccess" {
     grok {
-      match => { "message" => 
-        "%{COMBINEDAPACHELOG}"
+      match => { "message" =>
+        # jruby_duration is optional as it was added in Puppet Server
+        # 5.3.10 and 6.5.0.
+        "%{COMBINEDAPACHELOG} %{INT:duration:int} (?:%{INT:request_bytes:int}|-) (?:%{INT:jruby_duration:int}|-)?"
         }
       }
     date {


### PR DESCRIPTION
This commit updates the Logstash pipelines for parsing the access logs
of PE services to pick up request lengths and durations. The values of
these fields are cast to integers so that they may be summarized into
statistics such as mean, average, and percentiles.